### PR TITLE
feature Extend retrieval endpoint to allow image extension

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,13 @@ require:
 inherit_from:
   - .rubocop_todo.yml
 
+Layout/AlignHash:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - lib/tasks/prog_image_tasks.rake
+    - spec/**/*.rb
 Metrics/LineLength:
   Max: 120
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add Grape API Framework
 * Add image upload and retrieval endpoints
+* Extend retrieval endpoint to allow image extension
 
 #### Technical Improvements
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gem 'configatron'
 gem 'figaro'
 gem 'grape'
 gem 'grape-entity'
-gem 'mini_magick', '~> 4.8'
+gem 'mimemagic', require: false
+gem 'mini_magick', '~> 4.8', require: false
 gem 'puma', '~> 3.11'
 gem 'rack'
 gem 'require_all'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
     jaro_winkler (1.5.1)
     jmespath (1.4.0)
     method_source (0.9.0)
+    mimemagic (0.3.2)
     mini_magick (4.8.0)
     minitest (5.11.3)
     multi_json (1.13.1)
@@ -128,6 +129,7 @@ DEPENDENCIES
   figaro
   grape
   grape-entity
+  mimemagic
   mini_magick (~> 4.8)
   pry
   puma (~> 3.11)

--- a/app/api/prog_image/application_api.rb
+++ b/app/api/prog_image/application_api.rb
@@ -7,6 +7,8 @@ module ProgImage
 
     helpers ProgImage::Helpers::ApiResponseHelper
 
+    include ErrorsHandling
+
     mount Api::V10
 
     desc 'Application and API version information'

--- a/app/api/prog_image/concerns/errors_handling.rb
+++ b/app/api/prog_image/concerns/errors_handling.rb
@@ -1,0 +1,13 @@
+require 'active_support/concern'
+
+module ProgImage
+  module ErrorsHandling
+    extend ActiveSupport::Concern
+
+    included do
+      rescue_from ProgImage::Errors::ImageConversionError do |error|
+        error_response status: 422, message: { base: error.exception.message }
+      end
+    end
+  end
+end

--- a/app/api/prog_image/entities/image.rb
+++ b/app/api/prog_image/entities/image.rb
@@ -1,6 +1,7 @@
 module ProgImage
   module Entities
-    class Image < ImageKey
+    class Image < Grape::Entity
+      expose :key, documentation: { type: 'String', desc: 'Unique identifier for your image' }
       expose :public_url, documentation: { type: 'String', desc: 'URL image is located' }
     end
   end

--- a/app/api/prog_image/entities/image_key.rb
+++ b/app/api/prog_image/entities/image_key.rb
@@ -1,7 +1,0 @@
-module ProgImage
-  module Entities
-    class ImageKey < Grape::Entity
-      expose :key, documentation: { type: 'String', desc: 'Unique identifier for your image' }
-    end
-  end
-end

--- a/app/api/prog_image/helpers/api_response_helper.rb
+++ b/app/api/prog_image/helpers/api_response_helper.rb
@@ -17,6 +17,13 @@ module ProgImage
         say_unprocessable_entity
         present_form_errors form, Entities::Errors::UnprocessableEntity
       end
+
+      private
+
+      def present_form_errors(form, error_presenter)
+        form.errors.messages
+        present form, with: error_presenter
+      end
     end
   end
 end

--- a/app/api/prog_image/helpers/images_helper.rb
+++ b/app/api/prog_image/helpers/images_helper.rb
@@ -1,0 +1,47 @@
+module ProgImage
+  module Helpers
+    module ImagesHelper
+      def image_convert_form
+        @image_convert_form ||= ::ProgImage::ImageConvertForm.new \
+          params.slice(*permitted_convert_image_params)
+      end
+
+      def image_upload_form
+        @image_upload_form ||= ::ProgImage::ImageUploadForm.new \
+          params[:image_file].slice(*permitted_upload_image_params)
+      end
+
+      def permitted_convert_image_params
+        ::ProgImage::ImageConvertForm.permitted_params
+      end
+
+      def permitted_upload_image_params
+        ::ProgImage::ImageUploadForm.permitted_params
+      end
+
+      def perform_image_conversion!
+        if image_convert_form.persist
+          present image_convert_form, with: ProgImage::Entities::Image
+        else
+          say_unprocessable_entity_for image_convert_form
+        end
+      end
+
+      def image_key_exists?
+        file_fetcher.file_exists?
+      end
+
+      def presentable_object
+        params[:extension] ? image_convert_form.persist : formatted_image_details
+      end
+
+      def formatted_image_details
+        { key: file_fetcher.key, public_url: file_fetcher.fetch_file_url }
+      end
+
+      def file_fetcher
+        @file_fetcher ||= ProgImage::FileFetcher.new(params[:key])
+      end
+    end
+  end
+end

--- a/app/forms/prog_image/image_base_form.rb
+++ b/app/forms/prog_image/image_base_form.rb
@@ -1,0 +1,33 @@
+module ProgImage
+  class ImageBaseForm < BaseForm
+    attribute :filename, String
+    attribute :type, String
+    attribute :tempfile
+
+    def persist
+      raise NotImplementedError, 'must be defined in child class'
+    end
+
+    def public_url
+      file_fetcher.fetch_file_url
+    end
+
+    private
+
+    def upload_image
+      file_uploader.upload
+    end
+
+    def image_handler
+      @image_handler ||= ImageHandler.new(tempfile)
+    end
+
+    def file_uploader
+      @file_uploader ||= FileUploader.new(attributes)
+    end
+
+    def file_fetcher
+      FileFetcher.new(key)
+    end
+  end
+end

--- a/app/forms/prog_image/image_convert_form.rb
+++ b/app/forms/prog_image/image_convert_form.rb
@@ -1,0 +1,54 @@
+module ProgImage
+  class ImageConvertForm < ImageBaseForm
+    attribute :key, String
+    attribute :extension, String
+
+    include FileNaming
+
+    validate :ensure_extension_is_image, :ensure_extension_is_different, if: :extension
+
+    def initialize(*args)
+      super
+      @tempfile = file_fetcher.fetch_file
+      @extension ||= filename_extension(key)
+    end
+
+    def self.permitted_params
+      %i[key extension]
+    end
+
+    def persist
+      if valid?
+        convert_image!
+        upload_image!
+      else
+        false
+      end
+    end
+
+    private
+
+    def upload_image!
+      upload_image.tap do |updated_key|
+        update_key!(updated_key)
+      end
+    end
+
+    def update_key!(updated_key)
+      self.key = updated_key
+    end
+
+    def convert_image!
+      self.filename = filename_with_extension(filename_from_key(key), extension)
+      self.tempfile = image_handler.convert_extension(extension).tempfile
+    end
+
+    def ensure_extension_is_image
+      errors.add(:extension) unless image_handler.image_extension?(extension)
+    end
+
+    def ensure_extension_is_different
+      errors.add(:extension, :unchanged) unless image_handler.different_extension?(extension)
+    end
+  end
+end

--- a/app/forms/prog_image/image_upload_form.rb
+++ b/app/forms/prog_image/image_upload_form.rb
@@ -1,17 +1,12 @@
 module ProgImage
-  class ImageUploadForm < ::ProgImage::BaseForm
+  class ImageUploadForm < ImageBaseForm
     attr_reader :key
-
-    attribute :filename, String
-    attribute :type, String
-    attribute :head, String
-    attribute :tempfile
 
     validates :filename, format: { with: configatron.file.valid_filename_regex }
     validate :ensure_file_is_an_image
 
     def self.permitted_params
-      %i[filename type name tempfile head]
+      %i[filename type tempfile]
     end
 
     def persist
@@ -20,20 +15,8 @@ module ProgImage
 
     private
 
-    def upload_image
-      file_uploader.upload
-    end
-
     def ensure_file_is_an_image
       errors.add(:base) unless image_handler.image?
-    end
-
-    def image_handler
-      @image_handler ||= ImageHandler.new(tempfile)
-    end
-
-    def file_uploader
-      @file_uploader ||= FileUploader.new(attributes)
     end
   end
 end

--- a/app/lib/prog_image/connectors/aws/s3_connector.rb
+++ b/app/lib/prog_image/connectors/aws/s3_connector.rb
@@ -4,22 +4,35 @@ module ProgImage
   module Connectors
     module Aws
       class S3Connector < BaseConnector
-        def upload_file(file, key)
-          bucket.put_object file_upload_params(file, key)
+        include ProgImage::FileNaming
+
+        def fetch_file(key)
+          fetched_file = ::File.open("tmp/#{temporary_filename(key)}", 'wb') do |file|
+            client.get_object({ key: key, bucket: bucket_name }, target: file)
+          end
+          fetched_file.body
+        end
+
+        def fetch_file_url(key)
+          bucket.object(key).public_url
+        end
+
+        def file_exists?(key)
+          bucket.object(key).exists?
+        end
+
+        def upload_file(file_attributes, key)
+          bucket.put_object file_upload_params(file_attributes, key)
           true
         rescue ::Aws::S3::Errors, ::Timeout::Error
           false
         end
 
-        def fetch_file(key)
-          bucket.object(key)
-        end
-
         private
 
-        def file_upload_params(file, key)
+        def file_upload_params(file_attributes, key)
           {
-            body: file[:tempfile],
+            body: file_attributes[:tempfile],
             key: key,
             acl: 'public-read'
           }
@@ -27,6 +40,10 @@ module ProgImage
 
         def bucket
           @bucket ||= ::Aws::S3::Bucket.new region: region, credentials: credentials, name: bucket_name
+        end
+
+        def client
+          @client ||= ::Aws::S3::Client.new region: region, credentials: credentials
         end
 
         def bucket_name

--- a/app/lib/prog_image/errors.rb
+++ b/app/lib/prog_image/errors.rb
@@ -1,0 +1,15 @@
+module ProgImage
+  module Errors
+    class ImageConversionError < StandardError
+      def initialize(message = 'Image could not be converted', extension: nil)
+        super extended_message(message, extension)
+      end
+
+      private
+
+      def extended_message(message, extension)
+        extension.presence ? message + " to extension: #{extension}" : message
+      end
+    end
+  end
+end

--- a/app/lib/prog_image/file_naming.rb
+++ b/app/lib/prog_image/file_naming.rb
@@ -1,0 +1,23 @@
+module ProgImage
+  module FileNaming
+    def plain_filename(key)
+      filename_from_key(key).split('.').first
+    end
+
+    def filename_with_extension(original_filename, extension)
+      "#{plain_filename(original_filename)}.#{extension}"
+    end
+
+    def filename_from_key(key)
+      key.split('/').last
+    end
+
+    def filename_extension(key)
+      filename_from_key(key).split('.').last
+    end
+
+    def temporary_filename(key)
+      "#{SecureRandom.uuid}-#{filename_from_key(key)}"
+    end
+  end
+end

--- a/app/services/prog_image/file_fetcher.rb
+++ b/app/services/prog_image/file_fetcher.rb
@@ -6,8 +6,16 @@ module ProgImage
       @key = key
     end
 
-    def fetch
+    def fetch_file
       connector.fetch_file(key)
+    end
+
+    def fetch_file_url
+      connector.fetch_file_url(key)
+    end
+
+    def file_exists?
+      connector.file_exists?(key)
     end
 
     private

--- a/app/services/prog_image/file_uploader.rb
+++ b/app/services/prog_image/file_uploader.rb
@@ -1,20 +1,20 @@
 module ProgImage
   class FileUploader
-    attr_reader :file, :key
+    attr_reader :file_attributes, :key
 
-    def initialize(file)
-      @file = file
-      @key = build_key_path(file)
+    def initialize(file_attributes)
+      @file_attributes = file_attributes
+      @key = build_key_path
     end
 
     def upload
-      connector.upload_file(file, key) ? key : false
+      connector.upload_file(file_attributes, key) ? key : false
     end
 
     private
 
-    def build_key_path(file)
-      "#{SecureRandom.uuid}/#{file[:filename]}"
+    def build_key_path
+      "#{SecureRandom.uuid}/#{@file_attributes[:filename]}"
     end
 
     def connector

--- a/app/services/prog_image/image_handler.rb
+++ b/app/services/prog_image/image_handler.rb
@@ -1,13 +1,16 @@
+require 'mimemagic'
+require 'mini_magick'
+
 module ProgImage
   class ImageHandler
-    attr_reader :original_file
+    attr_reader :original_image_file
 
     def initialize(image_file)
-      @original_file = image_file
+      @original_image_file = image_file
     end
 
     def image_file
-      @image_file ||= handler.open(original_file.path)
+      handler.open(::File.open(original_image_file))
     rescue MiniMagick::Invalid
       nil
     end
@@ -16,14 +19,34 @@ module ProgImage
       !!image_file.presence
     end
 
+    def image_extension?(extension)
+      ::MimeMagic.by_extension(extension).image?
+    end
+
+    def different_extension?(extension)
+      image_file.type != extension.upcase
+    end
+
+    def convert_extension(extension)
+      if image_extension?(extension) && different_extension?(extension)
+        image_file.format(extension).tap do
+          clear_original_image_file!
+        end
+      elsif !different_extension?(extension)
+        original_image_file
+      end
+    rescue MiniMagick::Error
+      raise ProgImage::Errors::ImageConversionError, extension: extension
+    end
+
     private
 
     def handler
       ::MiniMagick::Image
     end
 
-    def supported_image_formats
-      configatron.file.supported_image_formats
+    def clear_original_image_file!
+      ::File.delete original_image_file
     end
   end
 end

--- a/config/locales/active_model.en.yml
+++ b/config/locales/active_model.en.yml
@@ -8,3 +8,12 @@ en:
               invalid: 'Filename is not a valid format'
             base:
               invalid: 'File is not an image or is unsupported'
+        prog_image/image_convert_form:
+          attributes:
+            filename:
+              invalid: 'Filename is not a valid format'
+            base:
+              invalid: 'File is not an image or is unsupported'
+            format:
+              invalid: 'Format is not an image or is unsupported'
+              unchanged: 'Format will be unchanged'

--- a/config/prog_image.rb
+++ b/config/prog_image.rb
@@ -7,11 +7,11 @@ module ProgImage
     end
 
     def root
-      Pathname.new File.dirname(File.expand_path(__dir__))
+      Pathname.new ::File.dirname(::File.expand_path(__dir__))
     end
 
     def version
-      @version ||= File.read(ProgImage.root.join('VERSION')).chomp.freeze
+      @version ||= ::File.read(ProgImage.root.join('VERSION')).chomp.freeze
     end
   end
 end

--- a/spec/api/prog_image/api/v10/images_spec.rb
+++ b/spec/api/prog_image/api/v10/images_spec.rb
@@ -4,17 +4,18 @@ RSpec.describe ProgImage::Api::V10::Images, type: :request do
 
   include_context 'with file for upload'
   include_context 'with aws s3 connector'
+  include_context 'with image handler'
 
   describe 'POST /api/v1.0/images' do
     let(:method) { :post }
     let(:params) { { image_file: image_file } }
 
-    it_behaves_like 'json body with keys', 'key'
+    it_behaves_like 'json body with keys', 'key', 'public_url'
   end
 
-  describe 'GET /api/v1.0/images/view' do
+  describe 'GET /api/v1.0/images' do
     let(:method) { :get }
-    let(:path) { build_api_path(path: '/images/view') }
+    let(:path) { build_api_path(path: '/images') }
     let(:params) { { key: key } }
 
     it_behaves_like 'json body with keys', 'key', 'public_url'

--- a/spec/forms/prog_image/image_convert_form_spec.rb
+++ b/spec/forms/prog_image/image_convert_form_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe ProgImage::ImageConvertForm do
+  subject(:form) { described_class.new params }
+
+  let(:params) { { 'extension' => extension, 'key' => key } }
+
+  include_context 'with file for upload'
+  include_context 'with aws s3 connector'
+  include_context 'with image handler'
+
+  describe '#valid?' do
+    let(:extension) { 'PNG' }
+
+    it { is_expected.to be_valid }
+
+    context 'when extension is not an image extension' do
+      let(:extension) { non_image_extension }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context 'when extension is the same type as image' do
+      let(:extension) { 'SVG' }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/spec/forms/prog_image/image_upload_form_spec.rb
+++ b/spec/forms/prog_image/image_upload_form_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ProgImage::ImageUploadForm do
   let(:params) { uploaded_image_file }
 
   include_context 'with file for upload'
+  include_context 'with aws s3 connector'
 
   describe '#valid?' do
     it { is_expected.to be_valid }

--- a/spec/lib/prog_image/connectors/aws/s3_connector_spec.rb
+++ b/spec/lib/prog_image/connectors/aws/s3_connector_spec.rb
@@ -4,10 +4,29 @@ RSpec.describe ProgImage::Connectors::Aws::S3Connector do
   include_context 'with file for upload'
   include_context 'with aws s3 connector'
 
+  describe '#fetch_file' do
+    subject { connector.fetch_file key }
+
+    it { is_expected.to be_kind_of File }
+  end
+
+  describe '#fetch_file_url' do
+    subject { connector.fetch_file_url key }
+
+    it { is_expected.to be_kind_of String }
+    it { is_expected.to include key }
+  end
+
+  describe '#file_exists?' do
+    subject { connector.file_exists? key }
+
+    it { is_expected.to eq true }
+  end
+
   describe '#upload_file' do
     subject { connector.upload_file uploaded_image_file, key }
 
-    it { is_expected.to be_truthy }
+    it { is_expected.to be true }
 
     context 'when request returns error' do
       let(:expected_errors) { [::Aws::S3::Errors::ServiceError, Timeout::Error] }
@@ -18,14 +37,7 @@ RSpec.describe ProgImage::Connectors::Aws::S3Connector do
       end
 
       # flashing test
-      xit { is_expected.to be_falsy }
+      xit { is_expected.to be false }
     end
-  end
-
-  describe '#fetch_file' do
-    subject { connector.fetch_file key }
-
-    it { is_expected.to be_kind_of ::Aws::S3::Object }
-    its(:key) { is_expected.to eq key }
   end
 end

--- a/spec/services/prog_image/file_fetcher_spec.rb
+++ b/spec/services/prog_image/file_fetcher_spec.rb
@@ -6,9 +6,21 @@ RSpec.describe ProgImage::FileFetcher do
 
   its(:key) { is_expected.to eq key }
 
-  describe '#fetch' do
-    subject { service.fetch }
+  describe '#fetch_file' do
+    subject { service.fetch_file }
 
-    its(:public_url) { is_expected.to include key }
+    it { is_expected.to be_kind_of File }
+  end
+
+  describe '#fetch_file_url' do
+    subject { service.fetch_file_url }
+
+    it { is_expected.to include key }
+  end
+
+  describe '#file_exists?' do
+    subject { service.file_exists? }
+
+    it { is_expected.to be true }
   end
 end

--- a/spec/services/prog_image/image_handler_spec.rb
+++ b/spec/services/prog_image/image_handler_spec.rb
@@ -30,4 +30,27 @@ RSpec.describe ProgImage::ImageHandler do
       it { is_expected.to be_falsey }
     end
   end
+
+  describe '#convert_extension' do
+    subject { service.convert_extension(extension) }
+
+    let(:file) { image_file }
+    let(:extension) { png_extension }
+    let(:png_extension) { 'PNG' }
+
+    it { is_expected.to be_kind_of MiniMagick::Image }
+    its(:type) { is_expected.to eq png_extension }
+
+    context 'when specified extension is not an image extension' do
+      let(:extension) { 'TXT' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when specified extension is the same as current image file' do
+      let(:extension) { 'SVG' }
+
+      it { is_expected.to eq image_file }
+    end
+  end
 end

--- a/spec/support/shared_contexts/with_aws_s3_connector.rb
+++ b/spec/support/shared_contexts/with_aws_s3_connector.rb
@@ -1,8 +1,12 @@
 RSpec.shared_context 'with aws s3 connector' do
   let(:aws_s3_connector_class) { ::ProgImage::Connectors::Aws::S3Connector }
   let(:stubbed_bucket) { Aws::S3::Bucket.new(stub_responses: true, name: bucket_name) }
+  let(:stubbed_client) { Aws::S3::Client.new(stub_responses: true) }
   let(:bucket_name) { 'example-bucket' }
   let(:stubbed_connector) { instance_double(aws_s3_connector_class.to_s) }
 
-  before { allow_any_instance_of(aws_s3_connector_class).to receive(:bucket).and_return stubbed_bucket }
+  before do
+    allow_any_instance_of(aws_s3_connector_class).to receive(:bucket).and_return stubbed_bucket
+    allow_any_instance_of(aws_s3_connector_class).to receive(:client).and_return stubbed_client
+  end
 end

--- a/spec/support/shared_contexts/with_image_handler.rb
+++ b/spec/support/shared_contexts/with_image_handler.rb
@@ -1,0 +1,7 @@
+RSpec.shared_context 'with image handler' do
+  let(:stubbed_image_file) { spec_upload_file(image_path, svg_content_type) }
+
+  before do
+    allow_any_instance_of(ProgImage::ImageHandler).to receive(:original_image_file).and_return stubbed_image_file
+  end
+end

--- a/spec/support/shared_methods/file_shared_methods.rb
+++ b/spec/support/shared_methods/file_shared_methods.rb
@@ -15,4 +15,8 @@ module FileSharedMethods
       'head' => ''
     }
   end
+
+  def non_image_extension
+    %w[TXT DOC XML HTML CSS JS EXE].sample
+  end
 end


### PR DESCRIPTION
This commit sees some refactoring of the previous commit to allow the GET /images endpoint to have :extension specified, which in the background will use the :key param to retrieve a previously uploaded image, convert it to the specified :extension, then upload the converted image to storage in order to provide a :public_url in the response body.